### PR TITLE
Resolve `ResultStore` from the `Container`

### DIFF
--- a/src/Pages/HealthCheckResults.php
+++ b/src/Pages/HealthCheckResults.php
@@ -7,7 +7,7 @@ use Filament\Pages\Actions\ButtonAction;
 use Filament\Pages\Page;
 use Illuminate\Support\Facades\Artisan;
 use Spatie\Health\Commands\RunHealthChecksCommand;
-use Spatie\Health\ResultStores\EloquentHealthResultStore;
+use Spatie\Health\ResultStores\ResultStore;
 
 class HealthCheckResults extends Page
 {
@@ -41,7 +41,7 @@ class HealthCheckResults extends Page
 
     protected function getViewData(): array
     {
-        $checkResults = (new EloquentHealthResultStore())->latestResults();
+        $checkResults = app(ResultStore::class)->latestResults();
 
         return [
             'lastRanAt' => new Carbon($checkResults?->finishedAt),


### PR DESCRIPTION
Hey 👋

`EloquentHealthResultStore` is currently hard-coded inside `getViewData`. However, not everyone writes the results to the database. This causes the page to crash when trying to visit.

After this change, people using other stores such as JSON will also be able to use this excellent plug-in.

Thanks!