### PR TITLE
Refactored to remove logic of view and created customizations on config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ This is the contents of the published config file:
 ```php
 return [
 
+    <?php
+
+use Spatie\Health\Enums\Status;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Navigation Icon
+    |--------------------------------------------------------------------------
+    |
+    | This is the configuration for the Navigation icon
+    |
+    | use the hero icon library https://heroicons.com/
+    | use prefix for apply icon
+    | `heroicon-o-` => outline
+    | `heroicon-s-` => solid
+    | `heroicon-m-` => mini
+    */
+    'navigation-icon' => 'heroicon-o-heart',
+
     /*
     |--------------------------------------------------------------------------
     | Pages
@@ -49,12 +69,113 @@ return [
         'health' => \ShuvroRoy\FilamentSpatieLaravelHealth\Pages\HealthCheckResults::class
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Background colors
+    |--------------------------------------------------------------------------
+    |
+    | This is the configuration for the status icon background color
+    |
+    */
+
+    'background-colors' => [
+        Status::ok()->value => 'bg-emerald-100',
+        Status::warning()->value => 'bg-yellow-100',
+        Status::skipped()->value => 'bg-blue-100',
+        Status::failed()->value => 'bg-red-100',
+        Status::crashed()->value => 'bg-red-100',
+        'default' => 'bg-gray-100',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Icon colors
+    |--------------------------------------------------------------------------
+    |
+    | This is the configuration for the status icon color
+    |
+    */
+
+    'icon-colors' => [
+        Status::ok()->value => 'text-emerald-500',
+        Status::warning()->value => 'text-yellow-500',
+        Status::skipped()->value => 'text-blue-500',
+        Status::failed()->value => 'text-red-500',
+        Status::crashed()->value => 'text-red-500',
+        'default' => 'text-gray-500',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Icons
+    |--------------------------------------------------------------------------
+    |
+    | This is the configuration for the status icon
+    |
+    */
+
+    'icons' => [
+        Status::ok()->value => 'heroicon-s-check-circle',
+        Status::warning()->value => 'heroicon-s-exclamation-circle',
+        Status::skipped()->value => 'heroicon-s-arrow-right-circle',
+        Status::failed()->value => 'heroicon-s-x-circle',
+        Status::crashed()->value => 'heroicon-s-x-circle',
+        'default' => 'heroicon-s-question-mark-circle',
+    ],
 ];
 ```
+
+Use the hero icon library https://heroicons.com/
+
+Use prefix for apply icon
+- `heroicon-o-`: outline
+- `heroicon-s-`: solid
+- `heroicon-m-`: mini
+
+Examples: 
+- heroicon-s-**check-circle** ![](https://api.iconify.design/material-symbols/check-circle-outline.svg)
+- heroicon-o-**check-circle** ![](https://api.iconify.design/heroicons/check-circle-solid.svg)
 
 ## Usage
 
 This package will automatically register the `HealthCheckResults`. You'll be able to see it when you visit your Filament admin panel.
+
+## Defining Resources to health check
+
+Register Health::checks on app/Providers/AppServiceProvider.php -> `boot` method
+
+```php
+<?php
+
+namespace App\Providers;
+
+...
+...
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\OptimizedAppCheck;
+use Spatie\Health\Checks\Checks\DebugModeCheck;
+use Spatie\Health\Checks\Checks\EnvironmentCheck;
+
+class AppServiceProvider extends ServiceProvider
+{
+    ...
+
+    public function boot()
+    {
+        ...
+    
+        Health::checks([
+            OptimizedAppCheck::new(),
+            DebugModeCheck::new(),
+            EnvironmentCheck::new(),
+            ...
+            ...
+        ]);
+    }
+}
+```
+
+Read the full documentation on [Spatie Laravel Health](https://spatie.be/docs/laravel-health/v1/available-checks/overview)
 
 ## Testing
 

--- a/config/filament-spatie-laravel-health.php
+++ b/config/filament-spatie-laravel-health.php
@@ -1,8 +1,24 @@
 <?php
 
-return [
+use Spatie\Health\Enums\Status;
 
-	/*
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Navigation Icon
+    |--------------------------------------------------------------------------
+    |
+    | This is the configuration for the Navigation icon
+    |
+    | use the hero icon library https://heroicons.com/
+    | use prefix for apply icon
+    | `heroicon-o-` => outline
+    | `heroicon-s-` => solid
+    | `heroicon-m-` => mini
+    */
+    'navigation-icon' => 'heroicon-o-heart',
+
+    /*
     |--------------------------------------------------------------------------
     | Pages
     |--------------------------------------------------------------------------
@@ -12,8 +28,61 @@ return [
     |
     */
 
-	'pages' => [
-		'health' => \ShuvroRoy\FilamentSpatieLaravelHealth\Pages\HealthCheckResults::class
+    'pages' => [
+        'health' => \ShuvroRoy\FilamentSpatieLaravelHealth\Pages\HealthCheckResults::class
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Background colors
+    |--------------------------------------------------------------------------
+    |
+    | This is the configuration for the status icon background color
+    |
+    */
+
+    'background-colors' => [
+        Status::ok()->value => 'bg-emerald-100',
+        Status::warning()->value => 'bg-yellow-100',
+        Status::skipped()->value => 'bg-blue-100',
+        Status::failed()->value => 'bg-red-100',
+        Status::crashed()->value => 'bg-red-100',
+        'default' => 'bg-gray-100',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Icon colors
+    |--------------------------------------------------------------------------
+    |
+    | This is the configuration for the status icon color
+    |
+    */
+
+    'icon-colors' => [
+        Status::ok()->value => 'text-emerald-500',
+        Status::warning()->value => 'text-yellow-500',
+        Status::skipped()->value => 'text-blue-500',
+        Status::failed()->value => 'text-red-500',
+        Status::crashed()->value => 'text-red-500',
+        'default' => 'text-gray-500',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Icons
+    |--------------------------------------------------------------------------
+    |
+    | This is the configuration for the status icon
+    |
+    */
+
+    'icons' => [
+        Status::ok()->value => 'heroicon-s-check-circle',
+        Status::warning()->value => 'heroicon-s-exclamation-circle',
+        Status::skipped()->value => 'heroicon-s-arrow-right-circle',
+        Status::failed()->value => 'heroicon-s-x-circle',
+        Status::crashed()->value => 'heroicon-s-x-circle',
+        'default' => 'heroicon-s-question-mark-circle',
+    ],
 ];

--- a/resources/lang/pt_BR/health.php
+++ b/resources/lang/pt_BR/health.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+
+    'pages' => [
+        'health_check_results' => [
+            'buttons' => [
+                'refresh' => 'Atualizar',
+            ],
+
+            'heading' => 'Saúde do aplicativo',
+
+            'navigation' => [
+                'group' => 'Configurações',
+                'label' => 'Saúde do aplicativo',
+            ],
+
+            'notifications' => [
+                'check_results' => 'Confira os resultados de',
+            ],
+        ],
+    ],
+
+];

--- a/resources/views/pages/health-check-results.blade.php
+++ b/resources/views/pages/health-check-results.blade.php
@@ -1,76 +1,32 @@
-@php
-	function backgroundColor($status) {
-		return match ($status) {
-			Spatie\Health\Enums\Status::ok()->value => 'bg-emerald-100',
-			Spatie\Health\Enums\Status::warning()->value => 'bg-yellow-100',
-			Spatie\Health\Enums\Status::skipped()->value => 'bg-blue-100',
-			Spatie\Health\Enums\Status::failed()->value, Spatie\Health\Enums\Status::crashed()->value => 'bg-red-100',
-			default => 'bg-gray-100'
-		};
-	}
-
-	function iconColor($status)
-	{
-		return match ($status) {
-			Spatie\Health\Enums\Status::ok()->value => 'text-emerald-500',
-			Spatie\Health\Enums\Status::warning()->value => 'text-yellow-500',
-			Spatie\Health\Enums\Status::skipped()->value => 'text-blue-500',
-			Spatie\Health\Enums\Status::failed()->value, Spatie\Health\Enums\Status::crashed()->value => 'text-red-500',
-			default => 'text-gray-500'
-		};
-	}
-
-	function icon($status)
-	{
-		return match ($status) {
-			Spatie\Health\Enums\Status::ok()->value => 'check-circle',
-			Spatie\Health\Enums\Status::warning()->value => 'exclamation-circle',
-			Spatie\Health\Enums\Status::skipped()->value => 'arrow-circle-right',
-			Spatie\Health\Enums\Status::failed()->value, Spatie\Health\Enums\Status::crashed()->value => 'x-circle',
-			default => ''
-		};
-	}
-@endphp
-
 <x-filament::page>
-	@if (count($checkResults?->storedCheckResults ?? []))
-		<dl class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-			@foreach ($checkResults->storedCheckResults as $result)
-				<div class="flex items-start p-6 space-x-2 rtl:space-x-reverse overflow-hidden text-opacity-0 transform bg-white rounded-xl shadow @if(config('filament.dark_mode')) dark:bg-gray-800 @endif">
-					<div class="flex justify-center items-center rounded-full p-2.5 {{ backgroundColor($result->status) }}">
-						<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 {{ iconColor($result->status) }}" viewBox="0 0 20 20" fill="currentColor">
-							@if(icon($result->status) == 'check-circle')
-								<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
-							@elseif(icon($result->status) == 'exclamation-circle')
-								<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-							@elseif(icon($result->status) == 'arrow-circle-right')
-								<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 1.414L10.586 9H7a1 1 0 100 2h3.586l-1.293 1.293a1 1 0 101.414 1.414l3-3a1 1 0 000-1.414z" clip-rule="evenodd" />
-							@elseif(icon($result->status) == 'x-circle')
-								<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-							@else
-								<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
-							@endif
-						</svg>
-					</div>
+    @if (count($storedCheckResults))
+        <dl class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            @foreach ($storedCheckResults as $result)
+                <div class="flex items-center items-start p-6 space-x-2 rtl:space-x-reverse overflow-hidden text-opacity-0 transform bg-white rounded-xl shadow @if(config('filament.dark_mode')) dark:bg-gray-800 @endif">
+                    <div class="flex justify-center rounded-full p-2.5 {{ $result->backgroundColor }}">
+                        @if ($result->icon)
+                            @svg($result->icon, "w-5 h-5 {$result->iconColor}")
+                        @endif
+                    </div>
 
-					<div>
-						<dd class="-mt-1 font-semibold text-gray-800 md:mt-1 md:text-xl @if(config('filament.dark_mode')) dark:text-gray-200 @endif">
-							{{ $result->label }}
-						</dd>
-						<dt class="mt-0 text-sm font-medium text-gray-600 md:mt-1 @if(config('filament.dark_mode'))dark:text-gray-400 @endif">
-							@if (!empty($result->notificationMessage))
-								{{ $result->notificationMessage }}
-							@else
-								{{ $result->shortSummary }}
-							@endif
-						</dt>
-					</div>
-				</div>
-			@endforeach
-		</dl>
-	@endif
+                    <div>
+                        <dd class="-mt-1 font-semibold text-gray-800 md:mt-1 md:text-xl @if(config('filament.dark_mode')) dark:text-gray-200 @endif">
+                            {{ $result->label }}
+                        </dd>
+                        <dt class="mt-0 text-sm font-medium text-gray-600 md:mt-1 @if(config('filament.dark_mode'))dark:text-gray-400 @endif">
+                            @if (!empty($result->notificationMessage))
+                                {{ $result->notificationMessage }}
+                            @else
+                                {{ $result->shortSummary }}
+                            @endif
+                        </dt>
+                    </div>
+                </div>
+            @endforeach
+        </dl>
+    @endif
 
-	@if ($lastRanAt)
+    @if ($lastRanAt)
         <div class="{{ $lastRanAt->diffInMinutes() > 5 ? 'text-red-400' : 'text-gray-500' }} text-md text-center font-medium">
             {{ __('filament-spatie-health::health.pages.health_check_results.notifications.check_results') }} {{ $lastRanAt->diffForHumans() }}
         </div>


### PR DESCRIPTION
**Problems**
- When the application is running with laravel octane the view methods (backgroundColor, iconColor, icon) are defined multiple times. So it is generating error
- To change the icons and colors it is necessary to publish the view


**Solution**
- Moved the methods `backgroundColor`, `iconColor`, `icon` to HealthCheckResults Page
- Created config entries to customization
   - **navigation-icon**: This is the configuration for the Navigation icon
   - **background-colors**: This is the configuration for the status icon background color
   - **icon-colors:** This is the configuration for the status icon color
   - **icons**: This is the configuration for the status icon


**Improviments**
- Moved `.items-center` class from icon div container to result div container to aling all content on center
- Added lang files for Brazilian Portuguese


Before moved items-center class
![before](https://user-images.githubusercontent.com/11270546/203870766-0bdc77ac-7df7-4706-b4f9-fc6575d26d3c.png)



After moved items-center class

![after](https://user-images.githubusercontent.com/11270546/203870779-bd70a636-56eb-42bb-8fb9-d539af260881.png)
