### PR TITLE
Added missing semicolon to README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ class HealthCheckResults extends BaseHealthCheckResults
 
     public function getHeading(): string | Htmlable
     {
-        return 'Health Check Results'
+        return 'Health Check Results';
     }
 
     public static function getNavigationGroup(): ?string


### PR DESCRIPTION
Just noticed this example was missing a semicolon.

Thanks for the package!