### PR TITLE
Fix Dutch translations

### DIFF
--- a/resources/lang/nl/health.php
+++ b/resources/lang/nl/health.php
@@ -16,7 +16,8 @@ return [
             ],
 
             'notifications' => [
-                'check_results' => 'Controleer resultaten van',
+                'check_results' => 'Gezondheidschecks resultaten van :lastRanAt',
+                'results_refreshed' => 'Gezondheidschecks resultaten zijn vernieuwd',
             ],
         ],
     ],


### PR DESCRIPTION
The `check_results` translation is missing the placeholder, and `check` is also incorrectly translated to the other meaning of check, it now translates to roughly "verify results of ..." instead of "check results from ..."

This PR fixes the above. It also adds the `results_refreshed` translation for NL.