### PR TITLE
Fix navigation translation issue

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -7,6 +7,11 @@ on:
       - 'phpstan.neon.dist'
       - '.github/workflows/phpstan.yml'
 
+  pull_request:
+    types:
+      - synchronize
+      - ready_for_review
+
 jobs:
   phpstan:
     name: phpstan

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,11 @@ on:
       - 'composer.json'
       - 'composer.lock'
 
+  pull_request:
+    types:
+      - synchronize
+      - ready_for_review
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/resources/lang/ar/health.php
+++ b/resources/lang/ar/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'إعدادات',
+        'label' => 'حالة النظام',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'حالة النظام',
-
-            'navigation' => [
-                'group' => 'إعدادات',
-                'label' => 'حالة النظام',
-            ],
 
             'notifications' => [
                 'check_results' => 'تمت عملية الفحص',

--- a/resources/lang/en/health.php
+++ b/resources/lang/en/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Settings',
+        'label' => 'Application Health',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Application Health',
-
-            'navigation' => [
-                'group' => 'Settings',
-                'label' => 'Application Health',
-            ],
 
             'notifications' => [
                 'check_results' => 'Check results from :lastRanAt',

--- a/resources/lang/es/health.php
+++ b/resources/lang/es/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Configuración',
+        'label' => 'Salud de la aplicación',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Salud de la aplicación',
-
-            'navigation' => [
-                'group' => 'Configuración',
-                'label' => 'Salud de la aplicación',
-            ],
 
             'notifications' => [
                 'check_results' => 'Revisar resultados desde',

--- a/resources/lang/fa/health.php
+++ b/resources/lang/fa/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'تنظیمات',
+        'label' => 'سلامت‌برنامه',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'سلامت‌برنامه',
-
-            'navigation' => [
-                'group' => 'تنظیمات',
-                'label' => 'سلامت‌برنامه',
-            ],
 
             'notifications' => [
                 'check_results' => 'بررسی نتایج از',

--- a/resources/lang/fr/health.php
+++ b/resources/lang/fr/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Paramètres',
+        'label' => 'Santé de l\'application',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Santé de l\'application',
-
-            'navigation' => [
-                'group' => 'Paramètres',
-                'label' => 'Santé de l\'application',
-            ],
 
             'notifications' => [
                 'check_results' => 'Résultats des vérifications à partir de',

--- a/resources/lang/it/health.php
+++ b/resources/lang/it/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Impostazioni',
+        'label' => 'Salute dell\'Applicazione',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Salute dell\'Applicazione',
-
-            'navigation' => [
-                'group' => 'Impostazioni',
-                'label' => 'Salute dell\'Applicazione',
-            ],
 
             'notifications' => [
                 'check_results' => 'Controlla i risultati da',

--- a/resources/lang/ja/health.php
+++ b/resources/lang/ja/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => '設定',
+        'label' => 'アプリケーションの健康状態',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'アプリケーションの健康状態',
-
-            'navigation' => [
-                'group' => '設定',
-                'label' => 'アプリケーションの健康状態',
-            ],
 
             'notifications' => [
                 'check_results' => '結果を確認する',

--- a/resources/lang/ka/health.php
+++ b/resources/lang/ka/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'პარამეტრები',
+        'label' => 'სერვერის ჯანმრთელობა',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'აპლიკაციის სტატუსი',
-
-            'navigation' => [
-                'group' => 'პარამეტრები',
-                'label' => 'სერვერის ჯანმრთელობა',
-            ],
 
             'notifications' => [
                 'check_results' => 'ბოლოს შემოწმდა:',

--- a/resources/lang/nl/health.php
+++ b/resources/lang/nl/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Instellingen',
+        'label' => 'Gezondheid van de applicatie',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Gezondheid van de applicatie',
-
-            'navigation' => [
-                'group' => 'Instellingen',
-                'label' => 'Gezondheid van de applicatie',
-            ],
 
             'notifications' => [
                 'check_results' => 'Controleer resultaten van',

--- a/resources/lang/pt_BR/health.php
+++ b/resources/lang/pt_BR/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Configurações',
+        'label' => 'Saúde da aplicação',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Saúde da aplicação',
-
-            'navigation' => [
-                'group' => 'Configurações',
-                'label' => 'Saúde da aplicação',
-            ],
 
             'notifications' => [
                 'check_results' => 'Ver resultados de verificação',

--- a/resources/lang/pt_PT/health.php
+++ b/resources/lang/pt_PT/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Configurações',
+        'label' => 'Saúde da Aplicação',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Saúde da Aplicação',
-
-            'navigation' => [
-                'group' => 'Configurações',
-                'label' => 'Saúde da Aplicação',
-            ],
 
             'notifications' => [
                 'check_results' => 'Verificar resultados de',

--- a/resources/lang/ru/health.php
+++ b/resources/lang/ru/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Настройки',
+        'label' => 'Состояние приложения',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Состояние приложения',
-
-            'navigation' => [
-                'group' => 'Настройки',
-                'label' => 'Состояние приложения',
-            ],
 
             'notifications' => [
                 'check_results' => 'Проверить результаты от',

--- a/resources/lang/sk/health.php
+++ b/resources/lang/sk/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Nastavenia',
+        'label' => 'Stav aplikácie',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Stav aplikácie',
-
-            'navigation' => [
-                'group' => 'Nastavenia',
-                'label' => 'Stav aplikácie',
-            ],
 
             'notifications' => [
                 'check_results' => 'Skontrolovať výsledky od',

--- a/resources/lang/tr/health.php
+++ b/resources/lang/tr/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Ayarlar',
+        'label' => 'Uygulama Sağlığı',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Uygulama Sağlığı',
-
-            'navigation' => [
-                'group' => 'Ayarlar',
-                'label' => 'Uygulama Sağlığı',
-            ],
 
             'notifications' => [
                 'check_results' => 'Sonuçları kontrol et.',

--- a/resources/lang/vi/health.php
+++ b/resources/lang/vi/health.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'navigation' => [
+        'group' => 'Cài đặt',
+        'label' => 'Tình trạng ứng dụng',
+    ],
+
     'pages' => [
         'health_check_results' => [
             'buttons' => [
@@ -9,11 +14,6 @@ return [
             ],
 
             'heading' => 'Tình trạng ứng dụng',
-
-            'navigation' => [
-                'group' => 'Cài đặt',
-                'label' => 'Tình trạng ứng dụng',
-            ],
 
             'notifications' => [
                 'check_results' => 'Kết quả được kiểm tra từ',

--- a/src/FilamentSpatieLaravelHealthPlugin.php
+++ b/src/FilamentSpatieLaravelHealthPlugin.php
@@ -48,7 +48,10 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
 
     public static function get(): static
     {
-        return filament(app(static::class)->getId());
+        /** @var static $instance */
+        $instance = filament(app(static::class)->getId());
+
+        return $instance;
     }
 
     public function getId(): string
@@ -80,9 +83,17 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
         return $this;
     }
 
-    public function getNavigationGroup(): string
+    public function getNavigationGroup(): ?string
     {
-        return $this->evaluate($this->navigationGroup) ?? __('filament-spatie-health::health.navigation.group');
+        if ($this->navigationGroup === null) {
+            if (app('translator')->has('filament-spatie-health::health.pages.navigation.group')) {
+                return __('filament-spatie-health::health.pages.navigation.group');
+            }
+
+            return __('filament-spatie-health::health.navigation.group');
+        }
+
+        return $this->evaluate($this->navigationGroup);
     }
 
     public function navigationSort(int | \Closure $navigationSort): static
@@ -118,6 +129,16 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
 
     public function getNavigationLabel(): string
     {
-        return $this->evaluate($this->navigationLabel) ?? __('filament-spatie-health::health.navigation.label');
+        $navigationLabel = $this->evaluate($this->navigationLabel);
+
+        if ($navigationLabel) {
+            return $navigationLabel;
+        }
+
+        if (app('translator')->has('filament-spatie-health::health.pages.navigation.label')) {
+            return __('filament-spatie-health::health.pages.navigation.label');
+        }
+
+        return __('filament-spatie-health::health.navigation.label');
     }
 }

--- a/src/Pages/HealthCheckResults.php
+++ b/src/Pages/HealthCheckResults.php
@@ -37,12 +37,12 @@ class HealthCheckResults extends Page
 
     public static function getNavigationGroup(): ?string
     {
-        return FilamentSpatieLaravelHealthPlugin::get()->getNavigationGroup() ?? __('filament-spatie-health::health.pages.health_check_results.navigation.group');
+        return FilamentSpatieLaravelHealthPlugin::get()->getNavigationGroup();
     }
 
     public static function getNavigationLabel(): string
     {
-        return FilamentSpatieLaravelHealthPlugin::get()->getNavigationLabel() ?? __('filament-spatie-health::health.pages.health_check_results.navigation.label');
+        return FilamentSpatieLaravelHealthPlugin::get()->getNavigationLabel();
     }
 
     public static function getNavigationSort(): ?int


### PR DESCRIPTION
This PR fixes translation issues introduced by #58
#58 also introduced PHPstan errors, which are also fixed by this PR.
Before #58 it was possible to not use a navigation group at all, but this was changed due to it never returning `null` anymore. That's also fixed in this PR.

Before:
![image](https://github.com/user-attachments/assets/9b5488ca-fff8-4eea-bc91-5f47bd093027)

After:
![image](https://github.com/user-attachments/assets/0801d7fe-7f9b-4e40-b299-6c3b0b317ba2)

fixes #62