### PR TITLE
Make PHPStan pass again

### DIFF
--- a/src/FilamentSpatieLaravelHealthPlugin.php
+++ b/src/FilamentSpatieLaravelHealthPlugin.php
@@ -13,6 +13,8 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
 
     protected bool | \Closure $authorizeUsing = true;
 
+    protected bool $navigationGroupSet = false;
+
     protected string $page = HealthCheckResults::class;
 
     protected string | \Closure | null $navigationGroup = null;
@@ -79,17 +81,20 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
     public function navigationGroup(string | \Closure | null $navigationGroup): static
     {
         $this->navigationGroup = $navigationGroup;
+        $this->navigationGroupSet = true;
 
         return $this;
     }
 
     public function getNavigationGroup(): ?string
     {
-        if ($this->navigationGroup === null) {
+        $navigationGroup = $this->evaluate($this->navigationGroup);
+
+        if ($navigationGroup === null && $this->navigationGroupSet === false) {
             return __('filament-spatie-health::health.pages.navigation.group');
         }
 
-        return $this->evaluate($this->navigationGroup);
+        return $navigationGroup;
     }
 
     public function navigationSort(int | \Closure $navigationSort): static

--- a/src/FilamentSpatieLaravelHealthPlugin.php
+++ b/src/FilamentSpatieLaravelHealthPlugin.php
@@ -48,7 +48,10 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
 
     public static function get(): static
     {
-        return filament(app(static::class)->getId());
+        /** @var static $instance */
+        $instance = filament(app(static::class)->getId());
+
+        return $instance;
     }
 
     public function getId(): string
@@ -80,9 +83,13 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
         return $this;
     }
 
-    public function getNavigationGroup(): string
+    public function getNavigationGroup(): ?string
     {
-        return $this->evaluate($this->navigationGroup) ?? __('filament-spatie-health::health.pages.navigation.group');
+        if ($this->navigationGroup === null) {
+            return __('filament-spatie-health::health.pages.navigation.group');
+        }
+
+        return $this->evaluate($this->navigationGroup);
     }
 
     public function navigationSort(int | \Closure $navigationSort): static

--- a/src/Pages/HealthCheckResults.php
+++ b/src/Pages/HealthCheckResults.php
@@ -37,12 +37,12 @@ class HealthCheckResults extends Page
 
     public static function getNavigationGroup(): ?string
     {
-        return FilamentSpatieLaravelHealthPlugin::get()->getNavigationGroup() ?? __('filament-spatie-health::health.pages.health_check_results.navigation.group');
+        return FilamentSpatieLaravelHealthPlugin::get()->getNavigationGroup();
     }
 
     public static function getNavigationLabel(): string
     {
-        return FilamentSpatieLaravelHealthPlugin::get()->getNavigationLabel() ?? __('filament-spatie-health::health.pages.health_check_results.navigation.label');
+        return FilamentSpatieLaravelHealthPlugin::get()->getNavigationLabel();
     }
 
     public static function getNavigationSort(): ?int


### PR DESCRIPTION
Fixes PHPStan errors.

Before #58 it was possible to not use a navigation group at all, but this was changed due to it never returning `null` anymore. This caused PHPStan errors which are fixed in this PR, also making it possible again to actually not use a navigation group.

`->navigationGroup(null)` will result in no navigation group and so will `->navigationGroup(fn () => null)`, the default and all other inputs will result in the same behaviour as before