### PR TITLE
Support UnitEnum for navigation group

### DIFF
--- a/src/FilamentSpatieLaravelHealthPlugin.php
+++ b/src/FilamentSpatieLaravelHealthPlugin.php
@@ -7,6 +7,7 @@ use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
 use ShuvroRoy\FilamentSpatieLaravelHealth\Pages\HealthCheckResults;
+use UnitEnum;
 
 class FilamentSpatieLaravelHealthPlugin implements Plugin
 {
@@ -18,7 +19,7 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
 
     protected string $page = HealthCheckResults::class;
 
-    protected string | Closure | null $navigationGroup = null;
+    protected string | UnitEnum | Closure | null $navigationGroup = null;
 
     protected int | Closure $navigationSort = 1;
 
@@ -79,7 +80,7 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
         return $this->page;
     }
 
-    public function navigationGroup(string | Closure | null $navigationGroup): static
+    public function navigationGroup(string | UnitEnum | Closure | null $navigationGroup): static
     {
         $this->navigationGroup = $navigationGroup;
         $this->navigationGroupSet = true;
@@ -87,7 +88,7 @@ class FilamentSpatieLaravelHealthPlugin implements Plugin
         return $this;
     }
 
-    public function getNavigationGroup(): ?string
+    public function getNavigationGroup(): string | UnitEnum | null
     {
         $navigationGroup = $this->evaluate($this->navigationGroup);
 

--- a/src/Pages/HealthCheckResults.php
+++ b/src/Pages/HealthCheckResults.php
@@ -9,6 +9,7 @@ use Filament\Pages\Page;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Artisan;
 use ShuvroRoy\FilamentSpatieLaravelHealth\FilamentSpatieLaravelHealthPlugin;
+use UnitEnum;
 use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\ResultStores\ResultStore;
 
@@ -35,7 +36,7 @@ class HealthCheckResults extends Page
         return __('filament-spatie-health::health.pages.health_check_results.heading');
     }
 
-    public static function getNavigationGroup(): ?string
+    public static function getNavigationGroup(): string | UnitEnum | null
     {
         return FilamentSpatieLaravelHealthPlugin::get()->getNavigationGroup();
     }


### PR DESCRIPTION
Align the navigationGroup property, setter, and getter with Filament v5's `Page::getNavigationGroup()` signature which accepts `string | UnitEnum | null`. 
This allows panels using enum-based navigation groups to pass them directly to the plugin.