### PR TITLE
Fix Russian translations

### DIFF
--- a/resources/lang/ru/health.php
+++ b/resources/lang/ru/health.php
@@ -16,7 +16,8 @@ return [
             ],
 
             'notifications' => [
-                'check_results' => 'Проверить результаты от',
+                'check_results' => 'Результаты проверки от :lastRanAt',
+                'results_refreshed' => 'Результаты проверки обновлены',
             ],
         ],
     ],


### PR DESCRIPTION
Improves the Russian translations for the health check results page.

- Fixes the `check_results` translation
- Adds the missing `:lastRanAt` placeholder
- Improves wording for the refreshed results notification